### PR TITLE
Preserve day freq on DatetimeIndex subtraction

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -758,6 +758,10 @@ Datetimelike
 - Bug in :meth:`to_datetime` reports incorrect index in case of any failure scenario. (:issue:`58298`)
 - Bug in :meth:`to_datetime` with ``format="ISO8601"`` and ``utc=True`` where naive timestamps incorrectly inherited timezone offset from previous timestamps in a series. (:issue:`61389`)
 - Bug in :meth:`to_datetime` wrongly converts when ``arg`` is a ``np.datetime64`` object with unit of ``ps``. (:issue:`60341`)
+- Bug in subtracting a :class:`Timestamp` from a :class:`DatetimeIndex` with
+  ``freq="D"`` dropping the frequency and causing subsequent
+  :meth:`TimedeltaIndex.shift` calls to raise ``NullFrequencyError``
+  (:issue:`62094`)
 - Bug in constructing arrays with :class:`ArrowDtype` with ``timestamp`` type incorrectly allowing ``Decimal("NaN")`` (:issue:`61773`)
 - Bug in constructing arrays with a timezone-aware :class:`ArrowDtype` from timezone-naive datetime objects incorrectly treating those as UTC times instead of wall times like :class:`DatetimeTZDtype` (:issue:`61775`)
 - Bug in setting scalar values with mismatched resolution into arrays with non-nanosecond ``datetime64``, ``timedelta64`` or :class:`DatetimeTZDtype` incorrectly truncating those scalars (:issue:`56410`)

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1089,6 +1089,16 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
             # e.g. TestTimedelta64ArithmeticUnsorted::test_timedelta
             # Day is unambiguously 24h
             return self.freq
+        elif (
+            lib.is_np_dtype(self.dtype, "M")
+            and isinstance(self.freq, Day)
+            and isinstance(other, Timestamp)
+            and (self.tz is None or timezones.is_utc(self.tz))
+            and (other.tz is None or timezones.is_utc(other.tz))
+        ):
+            # e.g. issue gh-62094: subtracting a Timestamp from a DTI
+            # with Day freq retains that freq
+            return self.freq
 
         return None
 

--- a/pandas/tests/indexes/timedeltas/methods/test_shift.py
+++ b/pandas/tests/indexes/timedeltas/methods/test_shift.py
@@ -74,3 +74,10 @@ class TestTimedeltaIndexShift:
         tdi = TimedeltaIndex(["1 days 01:00:00", "2 days 01:00:00"], freq=None)
         with pytest.raises(NullFrequencyError, match="Cannot shift with no freq"):
             tdi.shift(2)
+
+    def test_shift_after_dti_sub_timestamp(self):
+        dti = pd.date_range("1/1/2021", "1/5/2021")
+        tdi = dti - pd.Timestamp("1/3/2019")
+        result = tdi.shift(1)
+        expected = tdi + pd.Timedelta(days=1)
+        tm.assert_index_equal(result, expected)


### PR DESCRIPTION
## Summary
- retain `Day` frequency when subtracting a Timestamp from a DatetimeIndex
- add regression test for shifting TimedeltaIndex derived from DatetimeIndex subtraction
- document DatetimeIndex subtraction frequency preservation in v3.0.0 whatsnew

## Testing
- `pre-commit run --files pandas/core/arrays/datetimelike.py pandas/tests/indexes/timedeltas/methods/test_shift.py doc/source/whatsnew/v3.0.0.rst` *(command not found: pre-commit)*
- `pytest pandas/tests/indexes/timedeltas/methods/test_shift.py::TestTimedeltaIndexShift::test_shift_after_dti_sub_timestamp -q` *(ImportError: Unable to import required dependency numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689b799a91988331b87511be17919eeb