### PR TITLE
Cast self before tz check in _get_arithmetic_result_freq

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -1093,12 +1093,16 @@ class DatetimeLikeArrayMixin(  # type: ignore[misc]
             lib.is_np_dtype(self.dtype, "M")
             and isinstance(self.freq, Day)
             and isinstance(other, Timestamp)
-            and (self.tz is None or timezones.is_utc(self.tz))
-            and (other.tz is None or timezones.is_utc(other.tz))
         ):
-            # e.g. issue gh-62094: subtracting a Timestamp from a DTI
-            # with Day freq retains that freq
-            return self.freq
+            self = cast("DatetimeArray", self)
+            if (
+                self.tz is None or timezones.is_utc(self.tz)
+            ) and (
+                other.tz is None or timezones.is_utc(other.tz)
+            ):
+                # e.g. issue gh-62094: subtracting a Timestamp from a DTI
+                # with Day freq retains that freq
+                return self.freq
 
         return None
 


### PR DESCRIPTION
## Summary
- avoid mypy attr-defined error by casting to DatetimeArray before checking `tz`

## Testing
- `python -m py_compile pandas/core/arrays/datetimelike.py`
- `pre-commit run --files pandas/core/arrays/datetimelike.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest pandas/tests/arithmetic/test_timedelta64.py::test_td64arr_add_sub_datetimelike_scalar -q` *(fails: Unable to import required dependency numpy; Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_689b849647148331acbb399bd3b25483